### PR TITLE
Update _sidebar.md. Correct format of the doc-references.md

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
Deleted extra space after the name "doc-references".
Closes #2 .